### PR TITLE
Create basic internal representation - do not merge

### DIFF
--- a/core/src/main/java/com/kandm/save/game/Attribute.java
+++ b/core/src/main/java/com/kandm/save/game/Attribute.java
@@ -1,0 +1,32 @@
+package com.kandm.save.game;
+
+public class Attribute {
+
+    private final String identifier;
+    private final Object value;
+    private final Class<?> valueType;
+
+    public Attribute(final String identifier, final Object value) {
+        this.identifier = identifier;
+        this.value = value;
+        this.valueType = value.getClass();
+    }
+
+    public Attribute(final String identifier, final Object value, final Class<?> valueType) {
+        this.identifier = identifier;
+        this.value = value;
+        this.valueType = valueType;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Class<?> getValueType() {
+        return valueType;
+    }
+}

--- a/core/src/main/java/com/kandm/save/game/SaveGame.java
+++ b/core/src/main/java/com/kandm/save/game/SaveGame.java
@@ -1,0 +1,15 @@
+package com.kandm.save.game;
+
+import java.util.List;
+
+public class SaveGame {
+    private final List<Attribute> attributes;
+
+    public SaveGame(final List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+}

--- a/core/src/test/java/com/kandm/save/game/AttributeTest.java
+++ b/core/src/test/java/com/kandm/save/game/AttributeTest.java
@@ -1,0 +1,20 @@
+package com.kandm.save.game;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttributeTest {
+
+    @Test
+    public void shouldCorrectlySetTypeWhenTypeNotSpecified() {
+        // given
+        final Attribute attr = new Attribute("test", 42);
+
+        // when
+        final Class<?> valueType = attr.getValueType();
+
+        // then
+        assertEquals(valueType, Integer.class);
+    }
+}

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -11,4 +11,8 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
+
+    // parboiled
+    compile group: 'org.parboiled', name: 'parboiled-core', version: '1.1.8'
+    compile group: 'org.parboiled', name: 'parboiled-java', version: '1.1.8'
 }

--- a/parser/src/main/java/parser/ParadoxFileParser.java
+++ b/parser/src/main/java/parser/ParadoxFileParser.java
@@ -1,0 +1,40 @@
+package parser;
+
+import org.parboiled.Parboiled;
+import org.parboiled.parserunners.BasicParseRunner;
+import org.parboiled.parserunners.ParseRunner;
+import org.parboiled.support.ParsingResult;
+
+import java.io.*;
+import java.util.Optional;
+
+import static org.parboiled.common.FileUtils.readAllChars;
+
+/**
+ * Parses a file which uses Paradox's proprietary
+ * save-game file format.
+ */
+public class ParadoxFileParser {
+
+    private ParseRunner<Object> parseRunner;
+
+    public ParadoxFileParser() {
+        ParadoxParser paradoxParser = Parboiled.createParser(ParadoxParser.class);
+        parseRunner = new BasicParseRunner<>(paradoxParser.SaveGame());
+    }
+
+    public Optional<Object> parseFile(File file) {
+        return Optional.of(readAllChars(file)).map(input -> {
+            ParsingResult<Object> result = parseRunner.run(input);
+
+            if (result.hasErrors()) {
+                // TODO: Report these errors.
+                return Optional.empty();
+
+            } else {
+                // custom marshaller?
+                return Optional.of(result.parseTreeRoot.getValue());
+            }
+        });
+    }
+}

--- a/parser/src/main/java/parser/ParadoxParser.java
+++ b/parser/src/main/java/parser/ParadoxParser.java
@@ -1,0 +1,57 @@
+package parser;
+
+import org.parboiled.Action;
+import org.parboiled.BaseParser;
+import org.parboiled.Rule;
+import org.parboiled.annotations.BuildParseTree;
+import org.parboiled.support.Var;
+import representation.SaveGameTree;
+
+@BuildParseTree
+class ParadoxParser extends BaseParser<SaveGameTree> {
+
+    Rule SaveGame() {
+        Var<Integer> indentationLevel = new Var<>();
+        indentationLevel.set(0);
+        return Sequence(ZeroOrMore(ValuePair(indentationLevel)), EOI);
+    }
+
+    protected Rule ValuePair(Var<Integer> indentationLevel) {
+        return Sequence(
+                NTimes(indentationLevel.get(), INDENT),
+                Identifier(),
+                Ch('='),
+                Value(indentationLevel),
+                Optional('\n'));
+    }
+
+    protected Rule Identifier() {
+        return OneOrMore(AnyOf("abcdefghijklmnopqrstuvwxyz_"));
+    }
+
+    protected Rule Value(Var<Integer> indentationLevel) {
+        return FirstOf(
+                StringValue(),
+                DigitValue(),
+                RecursiveObjectValue(indentationLevel)
+        );
+    }
+
+    protected Rule StringValue() {
+        return Sequence('\"', OneOrMore(NoneOf("\"")), '\"');
+    }
+
+    protected Rule DigitValue() {
+        return OneOrMore(AnyOf("0123456789."));
+    }
+
+    protected Rule RecursiveObjectValue(Var<Integer> indentationLevel) {
+        return Sequence(
+                OneOrMore(INDENT),
+                "{\n",
+                indentationLevel.set(getContext().getMatchLength() + 1),
+                OneOrMore(ValuePair(indentationLevel)),
+                "}"
+        );
+    }
+}

--- a/parser/src/main/java/representation/SaveGameTree.java
+++ b/parser/src/main/java/representation/SaveGameTree.java
@@ -1,0 +1,4 @@
+package representation;
+
+public class SaveGameTree {
+}

--- a/parser/src/test/java/parser/ParadoxParserTest.java
+++ b/parser/src/test/java/parser/ParadoxParserTest.java
@@ -1,0 +1,72 @@
+package parser;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.parboiled.Parboiled;
+import org.parboiled.buffers.IndentDedentInputBuffer;
+import org.parboiled.parserunners.ParseRunner;
+import org.parboiled.parserunners.TracingParseRunner;
+import org.parboiled.support.ParsingResult;
+
+import static org.junit.Assert.assertFalse;
+import static org.parboiled.errors.ErrorUtils.printParseErrors;
+
+public class ParadoxParserTest {
+
+    private ParseRunner<Object> parseRunner;
+
+    @Before
+    public void setup() {
+        ParadoxParser paradoxParser = Parboiled.createParser(ParadoxParser.class);
+        parseRunner = new TracingParseRunner<>(paradoxParser.SaveGame());
+    }
+
+    @Test
+    public void shouldBeAbleToParseSimpleStringAttributes() {
+        // given
+        final String input = "identifier=\"string input\"";
+
+        // when
+        final ParsingResult<Object> result = parseRunner.run(input);
+
+        // then
+        assertNoParseErrors(result);
+    }
+
+
+    @Test
+    public void shouldBeAbleToParseSimpleNumericalAttributes() {
+        // given
+        final String input = "identifier=\"01234\"";
+
+        // when
+        final ParsingResult<Object> result = parseRunner.run(input);
+
+        // then
+        assertNoParseErrors(result);
+    }
+
+    @Test
+    public void shouldBeAbleToParseObjectAttribute() {
+        // given
+        final String input = "identifier={\n" +
+                "\tsubelem=\"value\"\n" +
+                "\totherelem=123\n" +
+                "}";
+
+        // when
+        final ParsingResult<Object> result = parseRunner.run(wrapWithBuffer(input));
+
+        // then
+        assertNoParseErrors(result);
+    }
+
+    private IndentDedentInputBuffer wrapWithBuffer(String input) {
+        return new IndentDedentInputBuffer(input.toCharArray(), 4, null, true, true);
+    }
+
+    private void assertNoParseErrors(ParsingResult<Object> result) {
+        assertFalse(printParseErrors(result), result.hasErrors());
+    }
+
+}

--- a/parser/src/test/resources/example.eu4
+++ b/parser/src/test/resources/example.eu4
@@ -1,0 +1,36 @@
+rebel_faction={
+	id={
+		id=571
+		type=50
+	}
+	type="noble_rebels"
+	name="Multani Noble Rebels"
+	heretic="Yazidi"
+	country="MUL"
+	religion="sunni"
+	government="feudal_monarchy"
+	province=2079
+	seed=981932888
+	general={
+		name="Bhenji Patidar"
+		dynasty="Patidar"
+		type=general
+		manuever=2
+		shock=1
+		siege=1
+		country="REB"
+		activation=1444.11.11
+		id={
+			id=1604
+			type=49
+		}
+	}
+	leader={
+		id=1604
+		type=49
+	}
+	possible_provinces={
+		2079 2086
+	}
+	active=no
+}


### PR DESCRIPTION
This is my general idea for the internal representation, a few notes;

- Unless we lock down the possible values a lot more, the attribute can only hold a value to at least an object representation, to remedy this there is a `valueType` value to reveal what value the attribute has.

Open to suggestions.